### PR TITLE
fix(memory.py): fix import handling for dependencies

### DIFF
--- a/modules/memory.py
+++ b/modules/memory.py
@@ -1,15 +1,63 @@
 import sys
 sys.path.append("../")
+
 from bw_utils import *
 from modules.embedding import get_embedding_model
-from langchain_experimental.generative_agents import GenerativeAgentMemory
-from langchain.retrievers import TimeWeightedVectorStoreRetriever
-from langchain_community.embeddings import HuggingFaceEmbeddings
-from langchain_community.llms import Tongyi,OpenAI
-from langchain_community.docstore import InMemoryDocstore
-from langchain_community.vectorstores import FAISS
+
+try:
+    from langchain_experimental.generative_agents.memory import GenerativeAgentMemory
+except Exception:
+    from langchain_experimental.generative_agents import GenerativeAgentMemory
+
+try:
+    from langchain_classic.retrievers import TimeWeightedVectorStoreRetriever
+except Exception:
+    try:
+        from langchain.retrievers import TimeWeightedVectorStoreRetriever
+    except Exception:
+        raise ImportError("装 langchain-classic")
+
+try:
+    from langchain_huggingface import HuggingFaceEmbeddings
+except Exception:
+    try:
+        from langchain_community.embeddings import HuggingFaceEmbeddings
+    except Exception:
+        raise ImportError("装 langchain-huggingface/langchain_community+sentence-transformers")
+
+try:
+    from langchain_community.llms.tongyi import Tongyi
+except Exception:
+    try:
+        from langchain_community.llms import Tongyi
+    except Exception:
+        Tongyi = None  
+
+try:
+    from langchain.llms import OpenAI
+except Exception:
+    try:
+        from langchain_community.llms import OpenAI
+    except Exception:
+        OpenAI = None
+
+try:
+    from langchain.docstore.in_memory import InMemoryDocstore
+except Exception:
+    from langchain_community.docstore.in_memory import InMemoryDocstore
+
+try:
+    from langchain.vectorstores.faiss import FAISS
+except Exception:
+    try:
+        from langchain.vectorstores import FAISS
+    except Exception:
+        from langchain_community.vectorstores.faiss import FAISS
+
+# 其它基础依赖
 import faiss
 import math
+
 
 def build_role_agent_memory(type = "ga",**kwargs):
     if type == "ga":


### PR DESCRIPTION
Root Cause:

The original project used modules such as langchain.retrievers.TimeWeightedVectorStoreRetriever, HuggingFaceEmbeddings from langchain_community, and Tongyi/FAISS.

With the release of LangChain v1, some modules were moved or split (e.g., retrievers moved to langchain-classic, HuggingFaceEmbeddings moved to langchain-huggingface).

As a result, the original import paths would trigger ModuleNotFoundError in the latest environment.

Fixes Applied:

Updated the import of TimeWeightedVectorStoreRetriever to langchain_classic.retrievers while keeping a backward-compatible fallback.

Prioritized importing HuggingFaceEmbeddings from langchain_huggingface, with a fallback to langchain_community.embeddings.