### PR TITLE
feat: add story upload to generate custom worlds from any novel text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ run.sh
 .vscode/
 nohup.out
 BookWorld_test.py
+.env
+.venv/
+*.local
+.gstack/

--- a/BookWorld.py
+++ b/BookWorld.py
@@ -964,6 +964,7 @@ class BookWorld():
                 location = f"Reaching {location_name}... ({distance})"
             chara_info = {
                 "id": i,
+                "code": code,
                 "name": agent.nickname,
                 "icon": agent.icon_path,
                 "description": agent.role_profile,
@@ -984,6 +985,7 @@ class BookWorld():
             icon_path = ""
         message = {
             'username': username,
+            'code': code,  # role_code of the speaker ("" for world/system) — used by the village view
             'type': message_type, # role, world, system
             'timestamp': datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             'text': text,
@@ -1056,6 +1058,7 @@ if __name__ == "__main__":
 
     parser.add_argument('--world_llm', type=str, default='gpt-4o-mini')
     parser.add_argument('--role_llm', type=str, default='gpt-4o-mini')
+    parser.add_argument('--embedding', type=str, default='embedding-3')
     parser.add_argument('--genre', type=str, default='mgdv2')
     parser.add_argument('--preset_path', type=str, default='')
 
@@ -1077,7 +1080,7 @@ if __name__ == "__main__":
     if not preset_path:
         preset_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),f"./experiment_presets/experiment_{genre}.json")
     
-    bw = BookWorld(preset_path, world_llm_name=world_llm_name, role_llm_name=role_llm_name)
+    bw = BookWorld(preset_path, world_llm_name=world_llm_name, role_llm_name=role_llm_name, embedding_name=args.embedding)
     bw.set_generator(rounds = rounds, save_dir = save_dir, if_save = if_save, scene_mode = scene_mode,mode = mode)
     
     for i in range(100):

--- a/bw_utils.py
+++ b/bw_utils.py
@@ -7,6 +7,13 @@ import re
 import random
 import base64
 
+# Load secrets (e.g. ZHIPUAI_API_KEY) from a gitignored .env if present.
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except Exception:
+    pass
+
 MODEL_NAME_DICT = {
     "gpt-3.5":"openai/gpt-3.5-turbo",
     "gpt-4":"openai/gpt-4",
@@ -71,6 +78,10 @@ def get_models(model_name):
         elif model_name.startswith('gemini-2.5-pro'):
             return Gemini(model="gemini-2.5-pro-preview-05-06")
         return Gemini()
+    elif model_name.startswith('glm') or model_name.startswith('charglm'):
+        # BigModel / Zhipu GLM family via OpenAI-compatible endpoint.
+        from modules.llm.GLM import GLM
+        return GLM(model=model_name)
     else:
         print(f'Warning! undefined model {model_name}, use gpt-4o-mini instead.')
         from modules.llm.LangChainGPT import LangChainGPT

--- a/frontend/css/right-section/upload-modal.css
+++ b/frontend/css/right-section/upload-modal.css
@@ -1,0 +1,204 @@
+/* Upload Story Modal */
+.upload-modal-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    z-index: 1000;
+    align-items: center;
+    justify-content: center;
+}
+
+.upload-modal-overlay.active {
+    display: flex;
+}
+
+.upload-modal {
+    background: #fff;
+    border-radius: 8px;
+    padding: 24px;
+    width: min(520px, 90vw);
+    max-height: 85vh;
+    overflow-y: auto;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.upload-modal h3 {
+    margin: 0;
+    color: #5f3737;
+    font-size: 1.1rem;
+}
+
+.upload-modal label {
+    font-size: 0.85rem;
+    color: #444;
+    margin-bottom: 2px;
+    display: block;
+}
+
+.upload-modal input[type="text"],
+.upload-modal select,
+.upload-modal textarea {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    color: #333;
+    background: #fafafa;
+}
+
+.upload-modal textarea {
+    height: 180px;
+    resize: vertical;
+    font-family: inherit;
+    line-height: 1.5;
+}
+
+.upload-modal-row {
+    display: flex;
+    gap: 12px;
+}
+
+.upload-modal-row > div {
+    flex: 1;
+}
+
+.upload-modal-hint {
+    font-size: 0.78rem;
+    color: #888;
+    margin-top: 2px;
+}
+
+/* file input area */
+.upload-file-area {
+    border: 2px dashed #c8a0a0;
+    border-radius: 6px;
+    padding: 14px;
+    text-align: center;
+    cursor: pointer;
+    color: #999;
+    font-size: 0.85rem;
+    transition: border-color 0.2s, background 0.2s;
+}
+
+.upload-file-area:hover {
+    border-color: #5f3737;
+    background: #fdf5f5;
+}
+
+.upload-file-area input[type="file"] {
+    display: none;
+}
+
+/* progress bar */
+.upload-progress-wrap {
+    display: none;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.upload-progress-wrap.active {
+    display: flex;
+}
+
+.upload-progress-bar-track {
+    width: 100%;
+    height: 8px;
+    background: #eee;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.upload-progress-bar-fill {
+    height: 100%;
+    background: #5f3737;
+    border-radius: 4px;
+    transition: width 0.4s ease;
+    width: 0%;
+}
+
+.upload-progress-label {
+    font-size: 0.82rem;
+    color: #666;
+    text-align: center;
+}
+
+/* action buttons */
+.upload-modal-actions {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+}
+
+.upload-cancel-btn {
+    padding: 8px 20px;
+    background: #f0f0f0;
+    color: #555;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: background 0.2s;
+}
+
+.upload-cancel-btn:hover {
+    background: #e0e0e0;
+}
+
+.upload-submit-btn {
+    padding: 8px 20px;
+    background: #5f3737;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: background 0.2s;
+}
+
+.upload-submit-btn:hover {
+    background: #7a4747;
+}
+
+.upload-submit-btn:disabled {
+    background: #bbb;
+    cursor: not-allowed;
+}
+
+/* success state */
+.upload-success {
+    background: #f0fff4;
+    border: 1px solid #b2dfdb;
+    border-radius: 6px;
+    padding: 12px;
+    font-size: 0.88rem;
+    color: #2e7d52;
+    display: none;
+}
+
+.upload-success.active {
+    display: block;
+}
+
+/* upload button in preset panel */
+.preset-upload-btn {
+    padding: 10px;
+    background: #fff;
+    color: #5f3737;
+    border: 1px solid #5f3737;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s, color 0.2s;
+    width: 100%;
+    font-size: 0.9rem;
+}
+
+.preset-upload-btn:hover {
+    background: #5f3737;
+    color: #fff;
+}

--- a/frontend/js/right-section/preset-panel.js
+++ b/frontend/js/right-section/preset-panel.js
@@ -5,12 +5,39 @@ class PresetPanel {
         this.container = document.querySelector('.preset-container');
         this.select = document.querySelector('.preset-select');
         this.submitBtn = document.querySelector('.preset-submit-btn');
+        this.uploadPanel = null;
         this.init();
     }
 
     init() {
         this.loadPresets();
         this.setupEventListeners();
+        this._injectUploadButton();
+    }
+
+    _injectUploadButton() {
+        if (!this.container) return;
+
+        const btn = document.createElement('button');
+        btn.className = 'preset-upload-btn';
+        btn.innerHTML = '<i class="fas fa-upload" style="margin-right:6px"></i>上传故事 / Upload Story';
+        this.container.appendChild(btn);
+
+        btn.addEventListener('click', () => {
+            if (!this.uploadPanel) {
+                this.uploadPanel = new window.UploadPanel((presetFile) => {
+                    // Refresh preset list and auto-select the new world
+                    this.loadPresets().then(() => {
+                        if (this.select) {
+                            this.select.value = presetFile;
+                            this.currentPreset = presetFile;
+                            if (this.submitBtn) this.submitBtn.disabled = false;
+                        }
+                    });
+                });
+            }
+            this.uploadPanel.show();
+        });
     }
 
     async loadPresets() {

--- a/frontend/js/right-section/upload-panel.js
+++ b/frontend/js/right-section/upload-panel.js
@@ -1,0 +1,221 @@
+/**
+ * UploadPanel — lets users paste or upload a story text to generate a new world.
+ *
+ * Usage: new UploadPanel(onSuccessCallback)
+ * The callback receives the preset filename when processing is done.
+ */
+class UploadPanel {
+    constructor(onSuccess) {
+        this.onSuccess = onSuccess || (() => {});
+        this._pollTimer = null;
+        this._buildDOM();
+        this._bindEvents();
+    }
+
+    /* ---- DOM construction ---- */
+
+    _buildDOM() {
+        this.overlay = document.createElement('div');
+        this.overlay.className = 'upload-modal-overlay';
+        this.overlay.innerHTML = `
+<div class="upload-modal">
+  <h3 data-i18n="uploadStoryTitle">上传故事 / Upload Story</h3>
+
+  <div class="upload-modal-row">
+    <div>
+      <label data-i18n="uploadStoryTitleLabel">故事标题 / Title</label>
+      <input type="text" id="up-title" placeholder="e.g. 红楼梦 / Dream of Red Mansions" />
+    </div>
+    <div style="flex:0 0 110px">
+      <label data-i18n="uploadLang">语言 / Language</label>
+      <select id="up-lang">
+        <option value="zh">中文</option>
+        <option value="en">English</option>
+      </select>
+    </div>
+  </div>
+
+  <div>
+    <label data-i18n="uploadTextLabel">粘贴故事内容 / Paste story text</label>
+    <textarea id="up-text" placeholder="粘贴小说正文（前几章即可）…"></textarea>
+    <div class="upload-modal-hint" data-i18n="uploadTextHint">
+      建议粘贴前 5,000–10,000 字，LLM 会自动提取角色、地点和世界观。
+    </div>
+  </div>
+
+  <div>
+    <label data-i18n="uploadFileLabel">或上传 .txt 文件 / Or upload a .txt file</label>
+    <label class="upload-file-area" id="up-file-label">
+      <input type="file" id="up-file" accept=".txt,.md" />
+      <i class="fas fa-file-upload" style="margin-right:6px"></i>
+      <span data-i18n="uploadFileDrop">点击选择文件 / Click to choose</span>
+    </label>
+  </div>
+
+  <div class="upload-progress-wrap" id="up-progress-wrap">
+    <div class="upload-progress-bar-track">
+      <div class="upload-progress-bar-fill" id="up-bar"></div>
+    </div>
+    <div class="upload-progress-label" id="up-step">初始化…</div>
+  </div>
+
+  <div class="upload-success" id="up-success"></div>
+
+  <div class="upload-modal-actions">
+    <button class="upload-cancel-btn" id="up-cancel">取消 / Cancel</button>
+    <button class="upload-submit-btn" id="up-submit">
+      <i class="fas fa-magic" style="margin-right:4px"></i>
+      生成世界 / Generate World
+    </button>
+  </div>
+</div>`;
+        document.body.appendChild(this.overlay);
+
+        // Shortcuts to key elements
+        this.titleInput = this.overlay.querySelector('#up-title');
+        this.langSelect = this.overlay.querySelector('#up-lang');
+        this.textArea   = this.overlay.querySelector('#up-text');
+        this.fileInput  = this.overlay.querySelector('#up-file');
+        this.progressWrap = this.overlay.querySelector('#up-progress-wrap');
+        this.bar        = this.overlay.querySelector('#up-bar');
+        this.stepLabel  = this.overlay.querySelector('#up-step');
+        this.successBox = this.overlay.querySelector('#up-success');
+        this.submitBtn  = this.overlay.querySelector('#up-submit');
+        this.cancelBtn  = this.overlay.querySelector('#up-cancel');
+    }
+
+    _bindEvents() {
+        this.cancelBtn.addEventListener('click', () => this.hide());
+        this.overlay.addEventListener('click', (e) => {
+            if (e.target === this.overlay) this.hide();
+        });
+
+        // File → textarea
+        this.fileInput.addEventListener('change', () => {
+            const file = this.fileInput.files[0];
+            if (!file) return;
+            if (!this.titleInput.value) {
+                this.titleInput.value = file.name.replace(/\.[^/.]+$/, '');
+            }
+            const reader = new FileReader();
+            reader.onload = (ev) => { this.textArea.value = ev.target.result; };
+            reader.readAsText(file, 'utf-8');
+        });
+
+        this.submitBtn.addEventListener('click', () => this._submit());
+    }
+
+    /* ---- public ---- */
+
+    show() {
+        this._resetUI();
+        this.overlay.classList.add('active');
+    }
+
+    hide() {
+        this.overlay.classList.remove('active');
+        if (this._pollTimer) { clearInterval(this._pollTimer); this._pollTimer = null; }
+    }
+
+    /* ---- internals ---- */
+
+    _resetUI() {
+        this.titleInput.value = '';
+        this.textArea.value = '';
+        this.fileInput.value = '';
+        this.progressWrap.classList.remove('active');
+        this.successBox.classList.remove('active');
+        this.successBox.textContent = '';
+        this.bar.style.width = '0%';
+        this.stepLabel.textContent = '初始化…';
+        this.submitBtn.disabled = false;
+    }
+
+    async _submit() {
+        const title = this.titleInput.value.trim() || 'Custom Story';
+        const language = this.langSelect.value;
+        const text = this.textArea.value.trim();
+
+        if (!text) {
+            alert('请先粘贴故事内容或上传文件。\nPlease paste story text or upload a file first.');
+            return;
+        }
+
+        this.submitBtn.disabled = true;
+        this.progressWrap.classList.add('active');
+        this.successBox.classList.remove('active');
+        this._setProgress(5, '提交故事文本… / Submitting…');
+
+        let taskId;
+        try {
+            const res = await fetch('/api/upload-story', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ title, language, text }),
+            });
+            if (!res.ok) {
+                const err = await res.json();
+                throw new Error(err.detail || 'Upload failed');
+            }
+            const data = await res.json();
+            taskId = data.task_id;
+        } catch (err) {
+            this._showError(err.message);
+            return;
+        }
+
+        // Poll for completion
+        this._pollTimer = setInterval(() => this._poll(taskId), 2000);
+    }
+
+    async _poll(taskId) {
+        try {
+            const res = await fetch(`/api/upload-story/${taskId}`);
+            if (!res.ok) return;
+            const data = await res.json();
+
+            if (data.status === 'processing') {
+                this._setProgress(data.progress || 0, data.step || '处理中…');
+            } else if (data.status === 'done') {
+                clearInterval(this._pollTimer);
+                this._pollTimer = null;
+                this._setProgress(100, '完成！/ Done!');
+                this._showSuccess(data);
+            } else if (data.status === 'error') {
+                clearInterval(this._pollTimer);
+                this._pollTimer = null;
+                this._showError(data.error || 'Unknown error');
+            }
+        } catch (_) { /* network hiccup, retry on next tick */ }
+    }
+
+    _setProgress(pct, label) {
+        this.bar.style.width = `${pct}%`;
+        this.stepLabel.textContent = label;
+    }
+
+    _showSuccess(data) {
+        this.successBox.classList.add('active');
+        this.successBox.innerHTML = `
+✅ 世界已生成！/ World generated!<br>
+<strong>${data.world_name || data.preset}</strong><br>
+角色 / Characters: ${data.character_count} &nbsp;|&nbsp; 地点 / Locations: ${data.location_count}<br>
+<em style="font-size:0.8em;color:#555">${data.preset}</em>`;
+        this.submitBtn.disabled = false;
+        this.onSuccess(data.preset);
+    }
+
+    _showError(msg) {
+        clearInterval(this._pollTimer);
+        this._pollTimer = null;
+        this.progressWrap.classList.remove('active');
+        this.successBox.classList.add('active');
+        this.successBox.style.background = '#fff5f5';
+        this.successBox.style.borderColor = '#ffcdd2';
+        this.successBox.style.color = '#c62828';
+        this.successBox.textContent = `❌ 错误 / Error: ${msg}`;
+        this.submitBtn.disabled = false;
+    }
+}
+
+window.UploadPanel = UploadPanel;

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="./frontend/css/right-section/status-panel.css">
     <link rel="stylesheet" href="./frontend/css/right-section/scene-panel.css">
     <link rel="stylesheet" href="./frontend/css/right-section/preset-panel.css">
+    <link rel="stylesheet" href="./frontend/css/right-section/upload-modal.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
@@ -168,6 +169,7 @@
     <script src="./frontend/js/right-section/settings-panel.js"></script>
     <script src="./frontend/js/right-section/status-panel.js"></script>
     <script src="./frontend/js/right-section/scene-panel.js"></script>
+    <script src="./frontend/js/right-section/upload-panel.js"></script>
     <script src="./frontend/js/right-section/preset-panel.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/modules/embedding.py
+++ b/modules/embedding.py
@@ -1,25 +1,31 @@
 import sys
 sys.path.append("../")
-from chromadb.api.types import Embeddings, Documents, EmbeddingFunction, Space
-from modelscope import AutoModel, AutoTokenizer
-from functools import partial
-from bw_utils import get_child_folders
-import torch
+from chromadb.api.types import Embeddings, Documents, EmbeddingFunction
 import os
+
+ZHIPU_BASE_URL = "https://open.bigmodel.cn/api/paas/v4/"
 
 
 class EmbeddingModel(EmbeddingFunction[Documents]):
+    """Local HuggingFace/ModelScope embedding model (bge, luotuo, ...).
+    The heavy `modelscope`/`torch` imports are loaded lazily so that the
+    API-embedding path does not require them to be installed."""
+
     def __init__(self, model_name, language='en'):
+        from modelscope import AutoModel, AutoTokenizer  # lazy: avoids torch unless used
+        import torch  # noqa: F401
+        from bw_utils import get_child_folders
+        self._torch = torch
         self.model_name = model_name
         self.language = language
         cache_dir = "~/.cache/modelscope/hub"
         model_provider = model_name.split("/")[0]
         model_smallname = model_name.split("/")[1]
         model_path = os.path.join(cache_dir, f"models--{model_provider}--{model_smallname}/snapshots/")
-        
+
         if os.path.exists(model_path) and get_child_folders(model_path):
             try:
-                model_path = os.path.join(model_path,get_child_folders(model_path)[0])
+                model_path = os.path.join(model_path, get_child_folders(model_path)[0])
                 self.tokenizer = AutoTokenizer.from_pretrained(model_path)
                 self.model = AutoModel.from_pretrained(model_path)
             except Exception as e:
@@ -32,18 +38,18 @@ class EmbeddingModel(EmbeddingFunction[Documents]):
 
     def __call__(self, input):
         inputs = self.tokenizer(input, return_tensors="pt", padding=True, truncation=True, max_length=256)
-        with torch.no_grad():
+        with self._torch.no_grad():
             outputs = self.model(**inputs)
         embeddings = outputs.last_hidden_state[:, 0, :].tolist()
         return embeddings
 
+
 class OpenAIEmbedding(EmbeddingFunction[Documents]):
-    def __init__(self, model_name="text-embedding-ada-002", base_url = "https://api.openai.com/v1/embeddings", api_key_field = "OPENAI_API_KEY"):
+    def __init__(self, model_name="text-embedding-ada-002", base_url="https://api.openai.com/v1/embeddings", api_key_field="OPENAI_API_KEY"):
         from openai import OpenAI
-            
         self.client = OpenAI(
-            base_url = base_url,
-            api_key = os.environ[api_key_field]
+            base_url=base_url,
+            api_key=os.environ[api_key_field]
         )
         self.model_name = model_name
 
@@ -51,23 +57,70 @@ class OpenAIEmbedding(EmbeddingFunction[Documents]):
         if isinstance(input, str):
             input = input.replace("\n", " ")
             return self.client.embeddings.create(input=[input], model=self.model_name).data[0].embedding
-        elif isinstance(input,list):
+        elif isinstance(input, list):
             return [self.client.embeddings.create(input=[sentence.replace("\n", " ")], model=self.model_name).data[0].embedding for sentence in input]
+
+
+class ZhipuEmbeddingFunction(EmbeddingFunction[Documents]):
+    """BigModel / Zhipu (智谱) embedding API (embedding-3 / embedding-2),
+    accessed through the OpenAI-compatible endpoint. Strong on Chinese,
+    so it is a good fit for classical-Chinese corpora like 《红楼梦》."""
+
+    BATCH = 64  # Zhipu accepts up to 64 inputs per request
+
+    def __init__(self, model_name="embedding-3", api_key_field="ZHIPUAI_API_KEY", dimensions=None):
+        from openai import OpenAI
+        api_key = os.getenv(api_key_field) or os.getenv("BIGMODEL_API_KEY")
+        self.client = OpenAI(api_key=api_key, base_url=ZHIPU_BASE_URL)
+        self.model_name = model_name
+        self.dimensions = dimensions
+
+    def __call__(self, input: Documents) -> Embeddings:
+        if isinstance(input, str):
+            input = [input]
+        out: Embeddings = []
+        for i in range(0, len(input), self.BATCH):
+            batch = [t.replace("\n", " ") for t in input[i:i + self.BATCH]]
+            kwargs = {"model": self.model_name, "input": batch}
+            if self.dimensions:
+                kwargs["dimensions"] = self.dimensions
+            resp = self.client.embeddings.create(**kwargs)
+            out.extend([d.embedding for d in resp.data])
+        return out
+
+    @staticmethod
+    def name() -> str:
+        return "zhipu"
+
+    def get_config(self):
+        return {"model_name": self.model_name, "dimensions": self.dimensions}
+
+    @staticmethod
+    def build_from_config(config):
+        return ZhipuEmbeddingFunction(
+            model_name=config.get("model_name", "embedding-3"),
+            dimensions=config.get("dimensions"),
+        )
+
 
 def get_embedding_model(embed_name, language='en'):
     local_model_dict = {
-        "bge-m3":"BAAI/bge-m3",
+        "bge-m3": "BAAI/bge-m3",
         "bge-large": f"BAAI/bge-large-{language}",
         "luotuo": "silk-road/luotuo-bert-medium",
         "bert": "google-bert/bert-base-multilingual-cased",
         "bge-small": f"BAAI/bge-small-{language}",
     }
+    # Online API embeddings, keyed by the name used in config.json.
+    zhipu_names = {"zhipu", "embedding-3", "embedding-2"}
+    if embed_name in zhipu_names:
+        model_name = "embedding-3" if embed_name in ("zhipu", "embedding-3") else embed_name
+        return ZhipuEmbeddingFunction(model_name=model_name)
     online_model_dict = {
         "openai":
-            {"model_name":"text-embedding-ada-002",
-             "url":"https://api.openai.com/v1/embeddings",
-             "api_key_field":"OPENAI_API_KEY"},
-
+            {"model_name": "text-embedding-ada-002",
+             "url": "https://api.openai.com/v1/embeddings",
+             "api_key_field": "OPENAI_API_KEY"},
     }
     if embed_name in local_model_dict:
         model_name = local_model_dict[embed_name]
@@ -76,5 +129,5 @@ def get_embedding_model(embed_name, language='en'):
         model_name = online_model_dict[embed_name]["model_name"]
         api_key_field = online_model_dict[embed_name]["api_key_field"]
         base_url = online_model_dict[embed_name]["url"]
-        return OpenAIEmbedding(model_name=model_name, base_url=base_url,api_key_field=api_key_field)
+        return OpenAIEmbedding(model_name=model_name, base_url=base_url, api_key_field=api_key_field)
     return EmbeddingModel(embed_name, language=language)

--- a/modules/llm/GLM.py
+++ b/modules/llm/GLM.py
@@ -1,0 +1,58 @@
+from .BaseLLM import BaseLLM
+from openai import OpenAI
+import os
+
+# BigModel / Zhipu AI (智谱) exposes an OpenAI-compatible endpoint.
+# Docs: https://open.bigmodel.cn/dev/api  ->  base_url ends in /api/paas/v4/
+ZHIPU_BASE_URL = "https://open.bigmodel.cn/api/paas/v4/"
+
+
+class GLM(BaseLLM):
+    """Adapter for the GLM family (glm-4-plus, glm-4-air, glm-4-flash, charglm-3, ...)
+    served by BigModel / Zhipu AI through its OpenAI-compatible API."""
+
+    def __init__(self, model="glm-4-plus"):
+        super(GLM, self).__init__()
+        api_key = os.getenv("ZHIPUAI_API_KEY") or os.getenv("BIGMODEL_API_KEY")
+        self.client = OpenAI(
+            api_key=api_key,
+            base_url=ZHIPU_BASE_URL,
+        )
+        self.model_name = model
+        self.messages = []
+
+    def initialize_message(self):
+        self.messages = []
+
+    def ai_message(self, payload):
+        self.messages.append({"role": "assistant", "content": payload})
+
+    def system_message(self, payload):
+        self.messages.append({"role": "system", "content": payload})
+
+    def user_message(self, payload):
+        self.messages.append({"role": "user", "content": payload})
+
+    def get_response(self, temperature=0.8):
+        kwargs = dict(
+            model=self.model_name,
+            messages=self.messages,
+            temperature=temperature,
+            stream=False,
+        )
+        # glm-5 / glm-4.5 are hybrid reasoning models: with thinking ON they spend the
+        # whole token budget reasoning and return empty content. Disable for direct answers.
+        import re
+        if re.search(r"glm-(5|4\.5)", self.model_name, re.I):
+            kwargs["extra_body"] = {"thinking": {"type": "disabled"}}
+        response = self.client.chat.completions.create(**kwargs)
+        return response.choices[0].message.content
+
+    def chat(self, text):
+        self.initialize_message()
+        self.user_message(text)
+        return self.get_response()
+
+    def print_prompt(self):
+        for message in self.messages:
+            print(message)

--- a/modules/memory.py
+++ b/modules/memory.py
@@ -4,63 +4,75 @@ sys.path.append("../")
 from bw_utils import *
 from modules.embedding import get_embedding_model
 
-try:
-    from langchain_experimental.generative_agents.memory import GenerativeAgentMemory
-except Exception:
-    from langchain_experimental.generative_agents import GenerativeAgentMemory
-
-try:
-    from langchain_classic.retrievers import TimeWeightedVectorStoreRetriever
-except Exception:
-    try:
-        from langchain.retrievers import TimeWeightedVectorStoreRetriever
-    except Exception:
-        raise ImportError("装 langchain-classic")
-
-try:
-    from langchain_huggingface import HuggingFaceEmbeddings
-except Exception:
-    try:
-        from langchain_community.embeddings import HuggingFaceEmbeddings
-    except Exception:
-        raise ImportError("装 langchain-huggingface/langchain_community+sentence-transformers")
-
-try:
-    from langchain_community.llms.tongyi import Tongyi
-except Exception:
-    try:
-        from langchain_community.llms import Tongyi
-    except Exception:
-        Tongyi = None  
-
-try:
-    from langchain.llms import OpenAI
-except Exception:
-    try:
-        from langchain_community.llms import OpenAI
-    except Exception:
-        OpenAI = None
-
-try:
-    from langchain.docstore.in_memory import InMemoryDocstore
-except Exception:
-    from langchain_community.docstore.in_memory import InMemoryDocstore
-
-try:
-    from langchain.vectorstores.faiss import FAISS
-except Exception:
-    try:
-        from langchain.vectorstores import FAISS
-    except Exception:
-        from langchain_community.vectorstores.faiss import FAISS
-
-# 其它基础依赖
-import faiss
 import math
+
+# The "generative agents" memory backend (LangChain + faiss + HuggingFace
+# embeddings, which pull in torch) is OPTIONAL. The default BookWorld run path
+# uses build_role_agent_memory(type="naive") -> the lightweight ChromaDB-backed
+# RoleMemory defined below. So we import the heavy deps lazily and degrade
+# gracefully when they are absent, keeping the install slim.
+try:
+    try:
+        from langchain_experimental.generative_agents.memory import GenerativeAgentMemory
+    except Exception:
+        from langchain_experimental.generative_agents import GenerativeAgentMemory
+
+    try:
+        from langchain_classic.retrievers import TimeWeightedVectorStoreRetriever
+    except Exception:
+        from langchain.retrievers import TimeWeightedVectorStoreRetriever
+
+    try:
+        from langchain_huggingface import HuggingFaceEmbeddings
+    except Exception:
+        from langchain_community.embeddings import HuggingFaceEmbeddings
+
+    try:
+        from langchain_community.llms.tongyi import Tongyi
+    except Exception:
+        try:
+            from langchain_community.llms import Tongyi
+        except Exception:
+            Tongyi = None
+
+    try:
+        from langchain.llms import OpenAI
+    except Exception:
+        try:
+            from langchain_community.llms import OpenAI
+        except Exception:
+            OpenAI = None
+
+    try:
+        from langchain.docstore.in_memory import InMemoryDocstore
+    except Exception:
+        from langchain_community.docstore.in_memory import InMemoryDocstore
+
+    try:
+        from langchain.vectorstores.faiss import FAISS
+    except Exception:
+        try:
+            from langchain.vectorstores import FAISS
+        except Exception:
+            from langchain_community.vectorstores.faiss import FAISS
+
+    import faiss
+    _GA_AVAILABLE = True
+except Exception:
+    # LangChain / faiss not installed -> only the "ga" backend is unavailable.
+    _GA_AVAILABLE = False
+    GenerativeAgentMemory = object  # placeholder base so the module still imports
+    Tongyi = None
+    OpenAI = None
 
 
 def build_role_agent_memory(type = "ga",**kwargs):
     if type == "ga":
+        if not _GA_AVAILABLE:
+            raise ImportError(
+                "The 'ga' memory backend needs langchain + faiss + sentence-transformers. "
+                "Install them, or use type='naive' (the default ChromaDB-backed memory)."
+            )
         llm_name = kwargs["llm_name"]
         embedding_name = kwargs["embedding_name"]
         db_name = kwargs["db_name"]

--- a/modules/story_processor.py
+++ b/modules/story_processor.py
@@ -1,0 +1,244 @@
+import os
+import re
+import json
+import csv
+
+
+class StoryProcessor:
+    """
+    Extracts world info, characters, and locations from a story text using LLM,
+    then writes all data files required by BookWorld and returns a preset filename.
+    """
+
+    def __init__(self, llm_name: str, progress_callback=None):
+        from bw_utils import get_models
+        self.llm = get_models(llm_name)
+        self._progress = progress_callback or (lambda step, pct: None)
+
+    # ------------------------------------------------------------------ helpers
+
+    def _call_llm(self, prompt: str) -> str:
+        self.llm.initialize_message()
+        self.llm.system_message(
+            "You are a literary analysis assistant. "
+            "Return ONLY valid JSON with no markdown fences."
+        )
+        self.llm.user_message(prompt)
+        return self.llm.get_response(temperature=0.3)
+
+    def _parse_json(self, text: str):
+        # Strip optional ```json … ``` fences the model may add
+        text = re.sub(r"```(?:json)?\s*", "", text)
+        text = re.sub(r"```", "", text).strip()
+        return json.loads(text)
+
+    @staticmethod
+    def _slugify(text: str) -> str:
+        slug = re.sub(r"[^a-zA-Z0-9_]", "_", text)
+        slug = re.sub(r"_+", "_", slug).strip("_")
+        return slug or "CustomWorld"
+
+    # ---------------------------------------------------------------- extraction
+
+    def _extract_world_info(self, text: str, title: str, language: str) -> dict:
+        lang_label = "Chinese" if language == "zh" else "English"
+        prompt = f"""Analyze the following novel excerpt and extract world background.
+
+Novel title: {title}
+Output language: {lang_label}
+
+Return a JSON object with these exact keys:
+{{
+  "world_slug": "Short_English_Identifier_for_filenames",
+  "world_name": "World name in {lang_label}",
+  "description": "One-sentence world summary in {lang_label}",
+  "detail": "3-5 sentence world description covering time period, society, culture in {lang_label}"
+}}
+
+Novel excerpt:
+{text[:5000]}"""
+
+        return self._parse_json(self._call_llm(prompt))
+
+    def _extract_characters(self, text: str, language: str, lang_suffix: str) -> list:
+        lang_label = "Chinese" if language == "zh" else "English"
+        gender_hint = "男/女" if language == "zh" else "Male/Female"
+        prompt = f"""Analyze the following novel excerpt and extract 4-8 main characters.
+
+Output language: {lang_label}
+Role code suffix: -{language}
+
+Return a JSON array with these exact keys per element:
+[
+  {{
+    "role_name": "Character name in {lang_label}",
+    "role_code": "CharacterEnglishPinyin-{language}",
+    "profile": "100-150 char personality/background description in {lang_label}",
+    "gender": "{gender_hint}",
+    "identity": ["Social role or title in {lang_label}"],
+    "relations": {{
+      "OtherRoleCode-{language}": {{
+        "relation": ["Relationship type in {lang_label}"],
+        "detail": "Relationship description in {lang_label}"
+      }}
+    }}
+  }}
+]
+
+Rules:
+- role_code uses only ASCII letters + hyphen, e.g. JiaBaoyu-zh
+- Include relations only for meaningful character pairs you can confirm from the text
+- Extract at least 4 characters
+
+Novel excerpt:
+{text[:8000]}"""
+
+        return self._parse_json(self._call_llm(prompt))
+
+    def _extract_locations(self, text: str, language: str) -> list:
+        lang_label = "Chinese" if language == "zh" else "English"
+        prompt = f"""Analyze the following novel excerpt and extract 4-8 main locations.
+
+Output language: {lang_label}
+
+Return a JSON array with these exact keys per element:
+[
+  {{
+    "location_code": "LocationEnglishName",
+    "location_name": "Location name in {lang_label}",
+    "description": "One-sentence description in {lang_label}",
+    "detail": "80-150 char detailed description in {lang_label}"
+  }}
+]
+
+Rules:
+- location_code uses only ASCII letters, no spaces or underscores
+- Extract real places mentioned in the novel
+
+Novel excerpt:
+{text[:5000]}"""
+
+        return self._parse_json(self._call_llm(prompt))
+
+    # ------------------------------------------------------------ file creation
+
+    def _write_files(self, world_slug: str, world_info: dict,
+                     characters: list, locations: list, language: str) -> str:
+        base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+        # -- world_info.json
+        world_dir = os.path.join(base, "data", "worlds", world_slug)
+        os.makedirs(world_dir, exist_ok=True)
+        world_data = {
+            "source": world_slug,
+            "title": world_info.get("world_name", world_slug),
+            "world_name": world_info.get("world_name", world_slug),
+            "language": language,
+            "description": world_info.get("description", ""),
+            "detail": world_info.get("detail", ""),
+        }
+        with open(os.path.join(world_dir, "world_info.json"), "w", encoding="utf-8") as f:
+            json.dump(world_data, f, ensure_ascii=False, indent=2)
+
+        # -- role files
+        role_codes = []
+        for role in characters:
+            code = self._slugify(role.get("role_code", ""))
+            if not code:
+                continue
+            role_dir = os.path.join(base, "data", "roles", world_slug, code)
+            os.makedirs(role_dir, exist_ok=True)
+            role_data = {
+                "role_code": code,
+                "role_name": role.get("role_name", code),
+                "nickname": role.get("role_name", code),
+                "source": world_slug,
+                "activity": 1,
+                "profile": role.get("profile", ""),
+                "gender": role.get("gender", ""),
+                "identity": role.get("identity", []),
+                "relation": role.get("relations", {}),
+            }
+            with open(os.path.join(role_dir, "role_info.json"), "w", encoding="utf-8") as f:
+                json.dump(role_data, f, ensure_ascii=False, indent=2)
+            role_codes.append(code)
+
+        # -- locations.json
+        loc_data = {}
+        loc_codes = []
+        for loc in locations:
+            code = self._slugify(loc.get("location_code", ""))
+            if not code:
+                continue
+            loc_data[code] = {
+                "location_code": code,
+                "location_name": loc.get("location_name", code),
+                "source": world_slug,
+                "description": loc.get("description", ""),
+                "detail": loc.get("detail", ""),
+            }
+            loc_codes.append(code)
+        os.makedirs(os.path.join(base, "data", "locations"), exist_ok=True)
+        with open(os.path.join(base, "data", "locations", f"{world_slug}.json"), "w", encoding="utf-8") as f:
+            json.dump(loc_data, f, ensure_ascii=False, indent=2)
+
+        # -- map CSV (all distances = 1)
+        os.makedirs(os.path.join(base, "data", "maps"), exist_ok=True)
+        map_path = os.path.join(base, "data", "maps", f"{world_slug}.csv")
+        with open(map_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow([""] + loc_codes)
+            for src in loc_codes:
+                writer.writerow([src] + [0 if src == dst else 1 for dst in loc_codes])
+
+        # -- experiment preset
+        preset_name = f"experiment_{world_slug}.json"
+        preset_data = {
+            "experiment_subname": world_slug,
+            "source": world_slug,
+            "title": world_info.get("world_name", world_slug),
+            "world_file_path": f"./data/worlds/{world_slug}/world_info.json",
+            "map_file_path": f"./data/maps/{world_slug}.csv",
+            "loc_file_path": f"./data/locations/{world_slug}.json",
+            "role_file_dir": "./data/roles/",
+            "role_agent_codes": role_codes,
+            "intervention": "",
+            "script": "",
+            "language": language,
+        }
+        os.makedirs(os.path.join(base, "experiment_presets"), exist_ok=True)
+        with open(os.path.join(base, "experiment_presets", preset_name), "w", encoding="utf-8") as f:
+            json.dump(preset_data, f, ensure_ascii=False, indent=2)
+
+        return preset_name
+
+    # ------------------------------------------------------------------ public
+
+    def process(self, story_text: str, title: str, language: str = "zh") -> dict:
+        """
+        Analyse story_text with LLM, write all required data files, and return
+        a dict with the new preset filename and extraction summary.
+        """
+        text = story_text[:10000]
+
+        self._progress("提取世界背景 / Extracting world info", 10)
+        world_info = self._extract_world_info(text, title, language)
+        world_slug = self._slugify(world_info.get("world_slug", title))
+
+        self._progress("提取角色信息 / Extracting characters", 40)
+        characters = self._extract_characters(text, language, f"-{language}")
+
+        self._progress("提取地点信息 / Extracting locations", 70)
+        locations = self._extract_locations(text, language)
+
+        self._progress("写入数据文件 / Writing data files", 90)
+        preset_name = self._write_files(world_slug, world_info, characters, locations, language)
+
+        self._progress("完成 / Done", 100)
+        return {
+            "preset": preset_name,
+            "world_name": world_info.get("world_name", world_slug),
+            "world_slug": world_slug,
+            "character_count": len(characters),
+            "location_count": len(locations),
+        }

--- a/server.py
+++ b/server.py
@@ -10,6 +10,9 @@ from datetime import datetime
 from bw_utils import is_image, load_json_file
 from BookWorld import BookWorld
 
+# In-memory store for background story-upload tasks: task_id -> status dict
+_upload_tasks: dict[str, dict] = {}
+
 app = FastAPI()
 default_icon_path = './frontend/assets/images/default-icon.jpg'
 config = load_json_file('config.json')
@@ -122,6 +125,12 @@ manager = ConnectionManager()
 @app.get("/")
 async def get():
     html_file = Path("index.html")
+    return HTMLResponse(html_file.read_text(encoding="utf-8"))
+
+@app.get("/village")
+async def get_village():
+    # AI Village-style top-down spatial view of 大观园.
+    html_file = Path("frontend/village.html")
     return HTMLResponse(html_file.read_text(encoding="utf-8"))
 
 @app.get("/data/{full_path:path}")
@@ -267,6 +276,52 @@ async def websocket_endpoint(websocket: WebSocket, client_id: str):
         print(f"WebSocket error: {e}")
     finally:
         manager.disconnect(client_id)
+
+@app.post("/api/upload-story")
+async def upload_story(request: Request):
+    """
+    Accept story text, process it with the LLM in the background, and return
+    a task_id the client can poll via GET /api/upload-story/{task_id}.
+    """
+    data = await request.json()
+    story_text = data.get("text", "").strip()
+    title = data.get("title", "Custom Story").strip() or "Custom Story"
+    language = data.get("language", "zh")
+
+    if not story_text:
+        raise HTTPException(status_code=400, detail="story text is empty")
+
+    task_id = datetime.now().strftime("%Y%m%d%H%M%S%f")
+    _upload_tasks[task_id] = {"status": "processing", "step": "initializing", "progress": 0}
+
+    async def _run():
+        loop = asyncio.get_event_loop()
+
+        def progress(step: str, pct: int):
+            _upload_tasks[task_id]["step"] = step
+            _upload_tasks[task_id]["progress"] = pct
+
+        def _process():
+            from modules.story_processor import StoryProcessor
+            processor = StoryProcessor(config["world_llm_name"], progress_callback=progress)
+            return processor.process(story_text, title, language)
+
+        try:
+            result = await loop.run_in_executor(None, _process)
+            _upload_tasks[task_id] = {"status": "done", **result}
+        except Exception as exc:
+            _upload_tasks[task_id] = {"status": "error", "error": str(exc)}
+
+    asyncio.create_task(_run())
+    return {"task_id": task_id}
+
+
+@app.get("/api/upload-story/{task_id}")
+async def get_upload_status(task_id: str):
+    if task_id not in _upload_tasks:
+        raise HTTPException(status_code=404, detail="task not found")
+    return _upload_tasks[task_id]
+
 
 @app.post("/api/save-config")
 async def save_config(request: Request):


### PR DESCRIPTION
## Summary

- **Story Upload feature**: users can paste or upload any novel text (Chinese or English) and have the LLM extract world background, characters (4–8), and locations (4–8), automatically generating a runnable experiment preset.
- **Zhipu GLM support**: new `modules/llm/GLM.py` adapter for the BigModel/Zhipu GLM family; routing added in `bw_utils.get_models`.
- **Dependency hardening**: heavy optional deps (`modelscope`, `torch`, `faiss`, LangChain-classic) are now imported lazily in `embedding.py` and `memory.py`, so BookWorld runs on slim Python environments that use API-only embeddings.
- **Minor fixes**: `BookWorld.py` now includes `code` in character/message dicts; `--embedding` CLI arg added; `.gitignore` extended.

## What changed

### Backend

**`modules/story_processor.py`** (new)
- `StoryProcessor` class: 3 sequential LLM calls extract world info, characters with relations, and locations.
- Writes all required data files (`data/worlds/`, `data/roles/`, `data/locations/`, `data/maps/`) and a new preset JSON under `experiment_presets/`.
- Accepts a `progress_callback` for real-time status reporting.

**`server.py`**
- `POST /api/upload-story` — accepts `{title, language, text}`, starts background extraction, returns `task_id` immediately.
- `GET /api/upload-story/{task_id}` — poll for `{status, progress, step}` until `status=done`.

### Frontend

- New **"上传故事 / Upload Story"** button in the Preset panel.
- Modal with title input, language selector (zh/en), textarea for paste, and `.txt` file upload.
- Real-time progress bar polling the task status endpoint.
- On success: preset list refreshes and the new world is pre-selected for loading.
- New `frontend/css/right-section/upload-modal.css` and `frontend/js/right-section/upload-panel.js`.

### GLM / Zhipu AI support

- `modules/llm/GLM.py`: OpenAI-compatible adapter for `glm-4-plus`, `glm-4-flash`, `glm-5`, `glm-5.1`, `charglm-3`, etc. via `open.bigmodel.cn`.
- Hybrid reasoning models (`glm-5`, `glm-4.5`) automatically get `thinking:{type:"disabled"}` to prevent empty content responses.
- `bw_utils.py`: GLM routing + optional `.env` loading via `python-dotenv`.

### Dependency hardening

- `modules/embedding.py`: `modelscope`/`torch` imports made lazy; added `ZhipuEmbeddingFunction` for Zhipu embedding-3 API.
- `modules/memory.py`: LangChain/faiss imports made lazy; graceful degradation when optional packages are absent.

## Test plan

- [ ] Upload a short excerpt of a novel → verify world/characters/locations are extracted and a preset is created under `experiment_presets/`
- [ ] Load the generated preset via the Preset panel → confirm simulation starts with the new world
- [ ] Test with both Chinese (`zh`) and English (`en`) stories
- [ ] Verify the progress bar updates while extraction is in progress
- [ ] Confirm server still loads normally without Zhipu API key configured (GLM is optional)
- [ ] Confirm `embedding.py` imports succeed in a torch-free environment (API embedding path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)